### PR TITLE
Change the help text of the --tag option

### DIFF
--- a/README
+++ b/README
@@ -70,7 +70,7 @@ Options:
     Please specify exactly one action (both update actions can be
     specified simultaniously).
 
-    -t, --tag           run the tag filter
+    -t, --tag           run the tag filters
     -l LEARN, --learn=LEARN
                         train the category with the messages matching the
                         given query

--- a/bin/afew
+++ b/bin/afew
@@ -39,7 +39,7 @@ action_group = optparse.OptionGroup(
 )
 action_group.add_option(
     '-t', '--tag', default = False, action = 'store_true',
-    help = 'run the tag filter'
+    help = 'run the tag filters'
 )
 action_group.add_option(
     '-l', '--learn', default = False,


### PR DESCRIPTION
Change the help text of the --tag option to reflect default behaviour of running several filters

Since the default is to run all tag filters, the help text for the --tag option now says 'run the tag filters' instead of 'run the tag filter'.

The documentation has been updated accordingly.

Signed-off-by: dtk dtk@gmx.de
