### PR TITLE
Fine-tune ArchiveSentMails filter

### DIFF
--- a/afew/filters/ArchiveSentMailsFilter.py
+++ b/afew/filters/ArchiveSentMailsFilter.py
@@ -23,7 +23,7 @@ from ..NotmuchSettings import notmuch_settings, get_notmuch_new_tags
 
 @register_filter
 class ArchiveSentMailsFilter(Filter):
-    message = 'Archiving all mails sent by myself'
+    message = 'Archiving all mails sent by myself to others'
 
     def __init__(self, sent_tag=''):
         super(ArchiveSentMailsFilter, self).__init__()
@@ -33,7 +33,13 @@ class ArchiveSentMailsFilter(Filter):
         if notmuch_settings.has_option('user', 'other_email'):
             my_addresses.update(filter_compat(None, notmuch_settings.get('user', 'other_email').split(';')))
 
-        self.query = ' OR '.join('from:"%s"' % address for address in my_addresses)
+        self.query = (
+            '(' + 
+            ' OR '.join('from:"%s"' % address for address in my_addresses)
+            + ') AND NOT (' +
+            ' OR '.join('to:"%s"'   % address for address in my_addresses)
+            + ')'
+        )
         self.sent_tag = sent_tag
 
 


### PR DESCRIPTION
Sometimes, at public computers that lack accessible USB ports (or when I have forgotten a flash drive), the only way for me to save documents, notes and other stuff is to log into my webmail and email it to myself. Unfortunately, I halfway lose such emails thanks to the ArchiveSentMails filter. This patch fine-tunes that filter such that only messages sent to others are retagged.
