### PR TITLE
fixed issue with the FolderNameFilter transforms failing on folder names with spaces

### DIFF
--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -21,6 +21,7 @@ from .BaseFilter import Filter
 from ..NotmuchSettings import notmuch_settings
 import re
 import logging
+import shlex
 
 
 class FolderNameFilter(Filter):
@@ -74,7 +75,7 @@ class FolderNameFilter(Filter):
         Parses the transformation rules specified in the config file.
         '''
         transformations = dict()
-        for rule in transformation_description.split():
+        for rule in shlex.split(transformation_description):
             folder, tag = rule.split(':')
             transformations[folder] = tag
         return transformations


### PR DESCRIPTION
fixed issue with the FolderNameFilter transforms failing on folder names with spaces
python shlex is now used for splitting and the following now works:
folder_transforms = Drafts:draft "Deleted Items:deleted" "Sent Items:sent" Sent:sent
