### PR TITLE
Fix some stuff in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         ],
     },
     install_requires=get_requires(),
-    provides='afew'
+    provides=['afew']
 )


### PR DESCRIPTION
Using python 3, we don't want to dependon subprocess32, that's a backport of a python 3 feature.

Also, the provides was getting something like

```
provides='a'
provides='f'
provides='e'
provides='w'
```

so fix that in the second patch.
