### PR TITLE
use getattr() with default intead of hasattr()

### DIFF
--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -59,7 +59,7 @@ class Filter(object):
     def run(self, query):
         logging.info(self.message)
 
-        if hasattr(self, 'query'):
+        if getattr(self, 'query', None):
             if query:
                 query = '(%s) AND (%s)' % (query, self.query)
             else:


### PR DESCRIPTION
When asking for the query attribute, use getattr('query', None)
rather than hasattr('query').  This prevents errors if a 'query'
attribute is available but empty or None.

This resolves issue #69.
