### PR TITLE
use message-id instead of str(message) in logs

### DIFF
--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -75,16 +75,19 @@ class Filter(object):
 
     def add_tags(self, message, *tags):
         if tags:
-            logging.debug('Adding tags %s to %s' % (', '.join(tags), message))
+            logging.debug('Adding tags %s to id:%s' % (', '.join(tags),
+                                                       message.get_message_id()))
             self._add_tags[message.get_message_id()].update(tags)
 
     def remove_tags(self, message, *tags):
         if tags:
-            logging.debug('Removing tags %s from %s' % (', '.join(tags), message))
+            logging.debug('Removing tags %s from id:%s' % (', '.join(tags),
+                                                           message.get_message_id()))
             self._remove_tags[message.get_message_id()].update(tags)
 
     def flush_tags(self, message):
-        logging.debug('Removing all tags from %s' % message)
+        logging.debug('Removing all tags from id:%s' %
+                      message.get_message_id())
         self._flush_tags.append(message.get_message_id())
 
     def commit(self, dry_run=True):


### PR DESCRIPTION
Using message-id in log messages makes it easier to identify individual
messages.

The existing string representation of a Message makes it difficult to identify a specific message.  This patch causes log messages to include the message id -- prefixed by `id:` so that it can be passed directly to `notmuch show`.  This makes it much easier to debug filter problems (since it becomes trivial to view the email associated with a particular log message).
