### PR TITLE
qualify list-id when generating tags

### DIFF
--- a/afew/filters/ListMailsFilter.py
+++ b/afew/filters/ListMailsFilter.py
@@ -25,4 +25,5 @@ class ListMailsFilter(HeaderMatchingFilter):
     query = 'NOT tag:lists'
     pattern = r"<(?P<list_id>[a-z0-9!#$%&'*+/=?^_`{|}~-]+)\."
     header = 'List-Id'
-    tags = ['+lists', '+{list_id}']
+    tags = ['+lists', '+lists/{list_id}']
+


### PR DESCRIPTION
Using an unqualified list-id as a tag name allows anyone sending you
mail to set arbitrary tags on messages.  This patch puts all list tags
in a 'list/' namespace.

For example, I could send you a message containing:

```
List-Id: This is very important <urgent.example.com>
```

And the existing `ListMailsFilter` would happily add the `urgent` tag to this message.
