### PR TITLE
FolderNameFilter handles messages in multiple folders.

### DIFF
--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -40,9 +40,18 @@ class FolderNameFilter(Filter):
 
 
     def handle_message(self, message):
-        maildirs = re.match(self.__filename_pattern, message.get_filename())
+        # Find all the dirs in the mail directory that this message
+        # belongs to
+        maildirs = [re.match(self.__filename_pattern, filename)
+                    for filename in message.get_filenames()]
+        maildirs = filter(None, maildirs)
         if maildirs:
-            folders = set(maildirs.group('maildirs').split(self.__maildir_separator))
+            # Make the folders relative to mail_root and split them.
+            folder_groups = [maildir.group('maildirs').split(self.__maildir_separator)
+                             for maildir in maildirs]
+            folders = set([folder
+                           for folder_group in folder_groups
+                           for folder in folder_group])
             logging.debug('found folders {} for message {!r}'.format(
                 folders, message.get_header('subject')))
 


### PR DESCRIPTION
The FolderNameFilter used to look only at a message's primary folder (message.get_filename()) when deciding which tags to apply. This change allows the filter to look at all folders that a message exists in when applying the tags.

This was done by retrieving all filenames using message.get_filenames() and adding the appropriate processing to handle the list of file names.

This change would be especially useful for those using GMail to add tags to their messages.
