### PR TITLE
add missing register_filter function

### DIFF
--- a/afew/FilterRegistry.py
+++ b/afew/FilterRegistry.py
@@ -68,3 +68,10 @@ class FilterRegistry(object):
 
 
 all_filters = FilterRegistry(pkg_resources.iter_entry_points('afew.filter'))
+
+def register_filter (klass):
+    '''Decorator function for registering a class as a filter.'''
+
+    all_filters[klass.__name__] = klass
+    return klass
+


### PR DESCRIPTION
This patch introduces a decorator, register_filter, that is used to
register a new filter class with afew:

   from afew.FilterRegistry import register_filter

```
@register_filter
class MySpiffyFilter(Filter):
    message = 'This filter does amazing things.'
```
