### PR TITLE
lowercase generated tag names

### DIFF
--- a/afew/filters/HeaderMatchingFilter.py
+++ b/afew/filters/HeaderMatchingFilter.py
@@ -21,6 +21,7 @@ class HeaderMatchingFilter(Filter):
                 value = message.get_header(self.header)
                 match = self.pattern.search(value)
                 if match:
-                    sub = lambda tag: tag.format(**match.groupdict())
+                    sub = (lambda tag:
+                        tag.format(**match.groupdict()).lower())
                     self.remove_tags(message, *map(sub, self._tags_to_remove))
                     self.add_tags(message, *map(sub, self._tags_to_add))


### PR DESCRIPTION
Rather than using header values verbatim, pull everything to
lower case when generating tag names.  This way when scanning tags I
don't need to remember that `Important`, `important`, and `ImPortAnt`
are actually all the same thing.
