### PR TITLE
commands.py: explicitly tag integer arguments as such

### DIFF
--- a/afew/commands.py
+++ b/afew/commands.py
@@ -109,12 +109,12 @@ options_group.add_option(
     help="don't change the db [default: %default]"
 )
 options_group.add_option(
-    '-R', '--reference-set-size', default=1000,
+    '-R', '--reference-set-size', type='int', default=1000,
     help='size of the reference set [default: %default]'
 )
 
 options_group.add_option(
-    '-T', '--reference-set-timeframe', default=30, metavar='DAYS',
+    '-T', '--reference-set-timeframe', type='int', default=30, metavar='DAYS',
     help='do not use mails older than DAYS days [default: %default]'
 )
 


### PR DESCRIPTION
--reference-set-size and --reference-set-timeframe should be declared as
integer types to optparse. If this is not done, they are parsed as
string objects, which triggers errors such as:

```
$ afew -vv --update-reference --reference-set-timeframe=360
Traceback (most recent call last):
  File "...snip.../.local/bin/afew", line 9, in <module>
    load_entry_point('afew==0.0.0', 'console_scripts', 'afew')()
  File
"...snip.../afew-0.0.0-py2.7.egg/afew/commands.py",
line 164, in main
    time.time() - options.reference_set_timeframe * 24 * 60 * 60,
TypeError: unsupported operand type(s) for -: 'float' and 'str'
```
