### PR TITLE
give filters a self.log attribute for better logging

### DIFF
--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -31,6 +31,9 @@ class Filter(object):
     def __init__(self, database, **kwargs):
         super(Filter, self).__init__()
 
+        self.log = logging.getLogger('{}.{}'.format(
+            self.__module__, self.__class__.__name__))
+
         self.database = database
         if 'tags' not in kwargs:
             kwargs['tags'] = self.tags
@@ -58,7 +61,7 @@ class Filter(object):
         self._flush_tags = []
 
     def run(self, query):
-        logging.info(self.message)
+        self.log.info(self.message)
 
         if getattr(self, 'query', None):
             if query:
@@ -76,18 +79,18 @@ class Filter(object):
 
     def add_tags(self, message, *tags):
         if tags:
-            logging.debug('Adding tags %s to id:%s' % (', '.join(tags),
+            self.log.debug('Adding tags %s to id:%s' % (', '.join(tags),
                                                        message.get_message_id()))
             self._add_tags[message.get_message_id()].update(tags)
 
     def remove_tags(self, message, *tags):
         if tags:
-            logging.debug('Removing tags %s from id:%s' % (', '.join(tags),
+            self.log.debug('Removing tags %s from id:%s' % (', '.join(tags),
                                                            message.get_message_id()))
             self._remove_tags[message.get_message_id()].update(tags)
 
     def flush_tags(self, message):
-        logging.debug('Removing all tags from id:%s' %
+        self.log.debug('Removing all tags from id:%s' %
                       message.get_message_id())
         self._flush_tags.append(message.get_message_id())
 
@@ -101,9 +104,9 @@ class Filter(object):
             return
 
         if dry_run:
-            logging.info('I would commit changes to %i messages' % len(dirty_messages))
+            self.log.info('I would commit changes to %i messages' % len(dirty_messages))
         else:
-            logging.info('Committing changes to %i messages' % len(dirty_messages))
+            self.log.info('Committing changes to %i messages' % len(dirty_messages))
             db = self.database.open(rw=True)
 
             for message_id in dirty_messages:
@@ -120,3 +123,4 @@ class Filter(object):
                         message.remove_tag(tag)
 
         self.flush_changes()
+

--- a/afew/filters/ClassifyingFilter.py
+++ b/afew/filters/ClassifyingFilter.py
@@ -17,8 +17,6 @@ from __future__ import print_function, absolute_import, unicode_literals
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-import logging
-
 from ..DBACL import DBACL as Classifier, ClassificationError
 from .BaseFilter import Filter
 from ..utils import extract_mail_body
@@ -34,7 +32,7 @@ class ClassifyingFilter(Filter):
         try:
             scores = self.classifier.classify(extract_mail_body(message))
         except ClassificationError as e:
-            logging.warning('Classification failed: {}'.format(e))
+            self.log.warning('Classification failed: {}'.format(e))
             return
 
         category = scores[0][0]

--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -20,7 +20,6 @@ from __future__ import print_function, absolute_import, unicode_literals
 from .BaseFilter import Filter
 from ..NotmuchSettings import notmuch_settings
 import re
-import logging
 import shlex
 
 
@@ -43,7 +42,7 @@ class FolderNameFilter(Filter):
         maildirs = re.match(self.__filename_pattern, message.get_filename())
         if maildirs:
             folders = set(maildirs.group('maildirs').split(self.__maildir_separator))
-            logging.debug('found folders {} for message {!r}'.format(
+            self.log.debug('found folders {} for message {!r}'.format(
                 folders, message.get_header('subject')))
 
             # remove blacklisted folders


### PR DESCRIPTION
This patch modifies BaseFilter.py to provide filter classes with their own
logger named after the name of the class. This makes it easier to identify which
filter modules are generating log messages (and would ultimately allow one to
apply different loglevels, etc., to different classes).
