### PR TITLE
Use XDG_DATA_HOME if it exists.

### DIFF
--- a/afew/DBACL.py
+++ b/afew/DBACL.py
@@ -26,7 +26,9 @@ import subprocess
 class ClassificationError(Exception): pass
 class BackendError(ClassificationError): pass
 
-default_db_path = os.path.expanduser('~/.local/share/afew/categories')
+default_db_path = os.path.join(os.environ.get('XDG_DATA_HOME',
+                                              os.path.expanduser('~/.local/share')),
+                               'afew', 'categories')
 
 class Classifier(object):
     reference_category = 'reference_category'


### PR DESCRIPTION
The code in `DBACL.py` hard-codes the path `~/.local/share/afew/categories` regardless of environment variables, contrary to what happens with the configuration files for afw and notmuch. This fixes the problem.

A possibly better solution would be to use `python-xdg` but that would add a dependency.
