### PR TITLE
Change semnatics of MailMover

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -87,7 +87,7 @@ class MailMover(Database):
         # update notmuch database
         logging.info("updating database")
         if not self.dry_run:
-            self.__update_db(maildir)
+            self.__update_db(rule_id)
         else:
             logging.info("Would update database")
 
@@ -96,7 +96,7 @@ class MailMover(Database):
     # private:
     #
 
-    def __update_db(self, maildir):
+    def __update_db(self, rule_id):
         '''
         Update the database after mail files have been moved in the filesystem.
         '''
@@ -104,7 +104,7 @@ class MailMover(Database):
             check_call(['notmuch', 'new'])
         except CalledProcessError as err:
             logging.error("Could not update notmuch database " \
-                          "after syncing maildir '{}': {}".format(maildir, err))
+                          "after syncing moving rule '{}': {}".format(rule_id, err))
             raise SystemExit
 
 

--- a/afew/main.py
+++ b/afew/main.py
@@ -78,9 +78,9 @@ def main(options, database, query_string):
 
             print('%s --> %s' % (message, category))
     elif options.move_mails:
-        for maildir, rules in options.mail_move_rules.items():
+        for rule_id, rules in options.mail_move_rules.items():
             mover = MailMover(options.mail_move_age, options.dry_run)
-            mover.move(maildir, rules)
+            mover.move(rule_id, rules)
             mover.close()
     else:
         sys.exit('Weird... please file a bug containing your command line.')


### PR DESCRIPTION
Hi,
I would like to propose a slight change in the semantics of `MailMover` rules. Right now, `MailMover` requires a fixed source folder for which a query applies. However, I find this very inconvenient for rules like 

```
Inbox = 'tag:deleted':Trash
```

since it requires to manually enter this rule for each maildir folder separately. This is especially inconvenient since notmuch also doesn't sync the deleted flag anymore.

The proposed patch changes the semantics of MailMover, such that `Trash =` in

```
Trash = 'tag:deleted AND NOT folder:Trash':Trash
```

only specifies the ID of the rule, but not the source folder. If a source folder is required, this could be added to the query separately, e.g.

```
Trash = 'tag:deleted AND folder:Inbox':Trash
```

I find this much more flexible then the previous semantics of `MailMover`.

However, I understand that this might break the setup for all users that currently rely on the old semantics. To fix this, the proposed `MailMover` could be added as an additional mover, e.g. `QueryBasedMailMover`.

Cheers,
Max
