### PR TITLE
[utils] avoid stripping all lines when no signature is found

### DIFF
--- a/afew/tests/test_utils.py
+++ b/afew/tests/test_utils.py
@@ -1,0 +1,40 @@
+#
+import unittest
+
+from afew import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_strip_signatures_base(self):
+        lines = ['Huhu', '--', 'Ikke']
+        self.assertEqual(['Huhu'], utils.strip_signatures(lines))
+
+    def test_strip_signatures_base_maxsig(self):
+        lines = [
+            'Huhu',
+            '--',
+            'Ikke',
+            '**',
+            "Sponsored by PowerDoh'",
+            "Sponsored by PowerDoh'",
+            "Sponsored by PowerDoh'",
+            "Sponsored by PowerDoh'",
+            "Sponsored by PowerDoh'",
+        ]
+        self.assertEqual(['Huhu'],
+                         utils.strip_signatures(lines, max_signature_size=5))
+
+    def test_strip_signatures_no_signature(self):
+        """no signature, nothing should be stripped"""
+        lines = '''
+        bla
+        bla
+        bla
+        '''.splitlines()
+        self.assertEqual(lines,
+                         utils.strip_signatures(lines, max_signature_size=2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/afew/utils.py
+++ b/afew/utils.py
@@ -72,7 +72,11 @@ def strip_signatures(lines, max_signature_size = 10):
 
         sigline_count += 1
 
-    return lines[:-siglines]
+    # a signature was found, strip it
+    if siglines:
+        return lines[:-siglines]
+    # otherwise, just return original content
+    return lines
 
 
 def extract_mail_body(message):


### PR DESCRIPTION
When no signature is found, siglines equals to 0 and lines[:-0] will strip off all lines rather than keeping content intact.
