### PR TITLE
afew.utils: fix DeprecationWarning: invalid escape sequence \.

### DIFF
--- a/afew/utils.py
+++ b/afew/utils.py
@@ -132,7 +132,7 @@ def get_message_summary(message):
 
 def get_sender(message):
     sender = message.get_header('From')
-    name_match = re.search('(.+) <.+@.+\..+>', sender)
+    name_match = re.search(r'(.+) <.+@.+\..+>', sender)
     if name_match:
         sender = name_match.group(1)
     return sender


### PR DESCRIPTION
we prefix the string with `r`, to avoid [The Backslash Plague](https://docs.python.org/2/howto/regex.html#the-backslash-plague)