### PR TITLE
Fix #136 learn/update not usable due to argparse migration

### DIFF
--- a/afew/commands.py
+++ b/afew/commands.py
@@ -50,7 +50,7 @@ action_group.add_argument(
     help='continuously monitor the mailbox for new files'
 )
 action_group.add_argument(
-    '-l', '--learn', action='store_true',
+    '-l', '--learn', action='store',
     help='train the category with the messages matching the given query'
 )
 action_group.add_argument(


### PR DESCRIPTION
Hi,
I double checked the prev code and seems after the argparse migration the learn option was not configured correctly.

I tested and seems it's working fine for me.

please have a look.