### PR TITLE
MailMover: Only run 'notmuch new' if any mails were actually moved

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -65,6 +65,7 @@ class MailMover(Database):
         # identify and move messages
         logging.info("checking mails in '{}'".format(maildir))
         to_delete_fnames = []
+        moved = False
         for query in rules.keys():
             destination = '{}/{}/cur/'.format(self.db_path, rules[query])
             main_query = self.query.format(folder=maildir, subquery=query)
@@ -78,6 +79,7 @@ class MailMover(Database):
                                   if maildir in name]
                 if not to_move_fnames:
                     continue
+                moved = True
                 self.__log_move_action(message, maildir, rules[query],
                                        self.dry_run)
                 for fname in to_move_fnames:
@@ -99,9 +101,10 @@ class MailMover(Database):
             os.remove(fname)
 
         # update notmuch database
-        logging.info("updating database")
         if not self.dry_run:
-            self.__update_db(maildir)
+            if moved:
+                logging.info("updating database")
+                self.__update_db(maildir)
         else:
             logging.info("Would update database")
 


### PR DESCRIPTION
When running `afew --move`, the notmuch database is always updated, even if not
files were actually moved. Since this takes a non-trivial amount of time, the
time to run afew can actually be dominated by the database update, which is
annoying when putting afew into an automated 'check new mails' hook.

This adds a small optimisation where the database is only updated if any
messages were actually moved. This makes running `afew --move` substantially
faster in the common case were no messages need to be moved.



I realise this pull requests conflicts with some of the other open pull requests
that also touch MailMover; but since this one is fairly small, it should be
simple to incorporate in those as well :)