### PR TITLE
Fix AttributeError: 'filter' object has no attribute 'remove'

### DIFF
--- a/afew/NotmuchSettings.py
+++ b/afew/NotmuchSettings.py
@@ -30,7 +30,7 @@ def read_notmuch_settings(path = None):
     notmuch_settings.readfp(open(path))
 
 def get_notmuch_new_tags():
-    tags = notmuch_settings.get_list('new', 'tags')
+    tags = list(notmuch_settings.get_list('new', 'tags'))
     try:
         tags.remove("unread")
     except ValueError:


### PR DESCRIPTION
Related issue is this one: https://github.com/afewmail/afew/issues/158