### PR TITLE
Turn iterable into a list before removing from it

### DIFF
--- a/afew/NotmuchSettings.py
+++ b/afew/NotmuchSettings.py
@@ -32,6 +32,7 @@ def read_notmuch_settings(path = None):
 def get_notmuch_new_tags():
     tags = notmuch_settings.get_list('new', 'tags')
     try:
+        tags = list(tags)
         tags.remove("unread")
     except ValueError:
         pass


### PR DESCRIPTION
Otherwise one would get an `AttributeError: 'filter' object has no
attribute 'remove'`.

The full stack trace is
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/luc/vcs/afew/afew/__main__.py", line 21, in <module>
    main()
  File "/home/luc/vcs/afew/afew/commands.py", line 131, in main
    query_string = get_notmuch_new_query()
  File "/home/luc/vcs/afew/afew/NotmuchSettings.py", line 41, in get_notmuch_new_query
    return '(%s)' % ' AND '.join('tag:%s' % tag for tag in get_notmuch_new_tags())
  File "/home/luc/vcs/afew/afew/NotmuchSettings.py", line 35, in get_notmuch_new_tags
    tags.remove("unread")
AttributeError: 'filter' object has no attribute 'remove'
```