### PR TITLE
Remove subprocess32 dependency per issue 64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ def get_requires():
     if os.environ.get('TRAVIS') != 'true':
         yield 'notmuch'
     yield 'chardet'
-    if version_info < (3, 0):
-        yield 'subprocess32'
 
 setup(
     name='afew',


### PR DESCRIPTION
The subprocess32 package is no longer used in code so can therefore be removed.

Per https://github.com/afewmail/afew/issues/64