### PR TITLE
Fix Sphinx warnings when building the documentation

### DIFF
--- a/docs/source/commandline.rst
+++ b/docs/source/commandline.rst
@@ -6,7 +6,7 @@ whether to act on all messages, or only on new messages.  The actions you can
 choose from are:
 
 tag
-  run the tag filters.  See :ref:`Initial tagging`.
+  run the tag filters.  See `Initial tagging`_.
 
 watch
   continuously monitor the mailbox for new files

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../..'))
 
 # Create mocks so we don't depend on non standard modules to build the
 # documentation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -239,7 +239,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/3.2', None),
-    'notmuch': ('http://packages.python.org/notmuch', None),
-    'alot': ('http://alot.readthedocs.org/en/latest', None),
+    'python': ('https://docs.python.org/', None),
+    'notmuch': ('https://notmuch.readthedocs.io/en/latest/', None),
+    'alot': ('https://alot.readthedocs.io/en/latest/', None),
 }

--- a/docs/source/implementation.rst
+++ b/docs/source/implementation.rst
@@ -14,7 +14,7 @@ manager :class:`alot.db.DBManager`.
 Filter
 ------
 
-.. module:: afew.Filter
+.. module:: afew.filters.BaseFilter
 .. autoclass:: Filter
    :members:
 


### PR DESCRIPTION
When building the documentation Sphinx warns about several things, which lead to certain omissions in the generated documentation. This pull request fixes these. Refer to the individual commit messages for the details.

This among others fixes #184.