### PR TITLE
Check for shutil.SameFileError

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -73,6 +73,9 @@ class MailMover(Database):
                     try:
                         shutil.copy2(fname, self.get_new_name(fname, destination))
                         to_delete_fnames.append(fname)
+                    except shutil.SameFileError:
+                        logging.warn("trying to move '{}' onto itself".format(fname))
+                        continue
                     except shutil.Error as e:
                         # this is ugly, but shutil does not provide more
                         # finely individuated errors


### PR DESCRIPTION
When copying a mail for MailMover, shutil.copy2 may failed because the
origin and source file are the same. In such a case, we should just
ignore the exception.

Fix #182