### PR TITLE
Add an --no-new option to afew --move-mails to not run notmuch-new

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -19,7 +19,7 @@ class MailMover(Database):
     '''
 
 
-    def __init__(self, max_age=0, rename = False, dry_run=False):
+    def __init__(self, max_age=0, rename = False, dry_run=False, no_new=False):
         super(MailMover, self).__init__()
         self.db = notmuch.Database(self.db_path)
         self.query = 'folder:{folder} AND {subquery}'
@@ -31,6 +31,7 @@ class MailMover(Database):
                                                        now=now.strftime('%s'))
         self.dry_run = dry_run
         self.rename = rename
+        self.run_new = not no_new
 
     def get_new_name(self, fname, destination):
         if self.rename:
@@ -106,7 +107,8 @@ class MailMover(Database):
         Update the database after mail files have been moved in the filesystem.
         '''
         try:
-            check_call(['notmuch', 'new'])
+            if self.run_new:
+                check_call(['notmuch', 'new'])
         except CalledProcessError as err:
             logging.error("Could not update notmuch database " \
                           "after syncing maildir '{}': {}".format(maildir, err))

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -75,6 +75,10 @@ options_group.add_argument(
     help="don't change the db [default: %(default)s]"
 )
 options_group.add_argument(
+    '-N', '--no-new', default=False, action='store_true',
+    help="do not run notmuch new after moving mails, you will have to run it manualy"
+)
+options_group.add_argument(
     '-R', '--reference-set-size', type=int, default=1000,
     help='size of the reference set [default: %(default)s]'
 )

--- a/afew/main.py
+++ b/afew/main.py
@@ -29,7 +29,7 @@ def main(options, database, query_string):
                             quick_find_dirs_hack(database.db_path))
     elif options.move_mails:
         for maildir, rules in options.mail_move_rules.items():
-            mover = MailMover(options.mail_move_age, options.mail_move_rename, options.dry_run)
+            mover = MailMover(options.mail_move_age, options.mail_move_rename, options.dry_run, options.no_new)
             mover.move(maildir, rules)
             mover.close()
     else:


### PR DESCRIPTION
I had difficulties because `afew --move-mails` run `notmuch new` several time, and this could create difficulties if `notmuch new` has `afew --tag` in hooks or anything that change tags. So i tried to add a option to not run `notmuch new`

