### PR TITLE
allow to specify args for notmuch new

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -34,11 +34,16 @@ class MailMover(Database):
 
     def get_new_name(self, fname, destination):
         if self.rename:
+            parts = os.path.basename(fname).split(':')
+            if len(parts) > 1:
+                flagpart = ':' + parts[-1]
+            else:
+                flagpart = ''
             return os.path.join(
                             destination,
                             # construct a new filename, composed of a made-up ID and the flags part
                             # of the original filename.
-                            str(uuid.uuid1()) + ':' + os.path.basename(fname).split(':')[-1]
+                            str(uuid.uuid1()) + flagpart
                         )
         else:
             return destination

--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -34,6 +34,7 @@ class MailMover(Database):
 
     def get_new_name(self, fname, destination):
         basename = os.path.basename(fname)
+        submaildir =  os.path.split(os.path.split(fname)[0])[1]
         if self.rename:
             parts = basename.split(':')
             if len(parts) > 1:
@@ -43,7 +44,7 @@ class MailMover(Database):
                             # construct a new filename, composed of a made-up ID and the flags part
                             # of the original filename.
             basename = str(uuid.uuid1()) + flagpart
-        return os.path.join(destination, basename)
+        return os.path.join(destination, submaildir, basename)
 
     def move(self, maildir, rules):
         '''
@@ -54,7 +55,7 @@ class MailMover(Database):
         to_delete_fnames = []
         moved = False
         for query in rules.keys():
-            destination = '{}/{}/cur/'.format(self.db_path, rules[query])
+            destination = '{}/{}/'.format(self.db_path, rules[query])
             main_query = self.query.format(
                 folder=maildir.replace("\"", "\\\""), subquery=query)
             logging.debug("query: {}".format(main_query))

--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -33,20 +33,17 @@ class MailMover(Database):
         self.rename = rename
 
     def get_new_name(self, fname, destination):
+        basename = os.path.basename(fname)
         if self.rename:
-            parts = os.path.basename(fname).split(':')
+            parts = basename.split(':')
             if len(parts) > 1:
                 flagpart = ':' + parts[-1]
             else:
                 flagpart = ''
-            return os.path.join(
-                            destination,
                             # construct a new filename, composed of a made-up ID and the flags part
                             # of the original filename.
-                            str(uuid.uuid1()) + flagpart
-                        )
-        else:
-            return destination
+            basename = str(uuid.uuid1()) + flagpart
+        return os.path.join(destination, basename)
 
     def move(self, maildir, rules):
         '''

--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -19,7 +19,7 @@ class MailMover(Database):
     '''
 
 
-    def __init__(self, max_age=0, rename = False, dry_run=False):
+    def __init__(self, max_age=0, rename = False, dry_run=False, notmuch_args=''):
         super().__init__()
         self.db = notmuch.Database(self.db_path)
         self.query = 'folder:"{folder}" AND {subquery}'
@@ -31,6 +31,7 @@ class MailMover(Database):
                                                        now=now.strftime('%s'))
         self.dry_run = dry_run
         self.rename = rename
+        self.notmuch_args = notmuch_args
 
     def get_new_name(self, fname, destination):
         basename = os.path.basename(fname)
@@ -110,7 +111,7 @@ class MailMover(Database):
         Update the database after mail files have been moved in the filesystem.
         '''
         try:
-            check_call(['notmuch', 'new'])
+            check_call(['notmuch', 'new'] + self.notmuch_args.split())
         except CalledProcessError as err:
             logging.error("Could not update notmuch database " \
                           "after syncing maildir '{}': {}".format(maildir, err))

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -89,6 +89,10 @@ options_group.add_argument(
     help='be more verbose, can be given multiple times'
 )
 
+options_group.add_argument(
+    '-N', '--notmuch-args', default='',
+    help='arguments for notmuch new (in move mode)'
+)
 
 def main():
     if sys.version_info < (3,4):

--- a/afew/main.py
+++ b/afew/main.py
@@ -29,7 +29,7 @@ def main(options, database, query_string):
                             quick_find_dirs_hack(database.db_path))
     elif options.move_mails:
         for maildir, rules in options.mail_move_rules.items():
-            mover = MailMover(options.mail_move_age, options.mail_move_rename, options.dry_run)
+            mover = MailMover(options.mail_move_age, options.mail_move_rename, options.dry_run, options.notmuch_args)
             mover.move(maildir, rules)
             mover.close()
     else:

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -63,6 +63,10 @@ traditional mail server. Tag your mails with notmuch, call afew
 `--move-mails` in an offlineimap presynchook and enjoy a clean inbox
 in your webinterface/GUI-client at work.
 
+Note that in move mode, afew calls `notmuch new` after moving mails around.
+You can use `afew -m --notmuch-args=--no-hooks` in a pre-new notmuch hook
+to avoid loops.
+
 For information on how to configure rules for move mode, what you can
 do with it and what you can't, please refer to :doc:`move_mode`.
 


### PR DESCRIPTION
In move mode, afew calls `notmuch new` after moving mails around. This
prevents `afew -m` from being used in a pre-new hook in `notmuch`.

Allow to specify args, so that `afew -m --notmuch-args=--no-hooks` can
live happily in a pre-new hook.