### PR TITLE
Mail mover fix renames

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -34,11 +34,16 @@ class MailMover(Database):
 
     def get_new_name(self, fname, destination):
         if self.rename:
+            parts = os.path.basename(fname).split(':')
+            if len(parts) > 1:
+                flagpart = ':' + parts[-1]
+            else:
+                flagpart = ''
             return os.path.join(
                             destination,
                             # construct a new filename, composed of a made-up ID and the flags part
                             # of the original filename.
-                            str(uuid.uuid1()) + ':' + os.path.basename(fname).split(':')[-1]
+                            str(uuid.uuid1()) + flagpart
                         )
         else:
             return destination

--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -34,6 +34,7 @@ class MailMover(Database):
 
     def get_new_name(self, fname, destination):
         basename = os.path.basename(fname)
+        submaildir =  os.path.split(os.path.split(fname)[0])[1]
         if self.rename:
             parts = basename.split(':')
             if len(parts) > 1:
@@ -43,7 +44,7 @@ class MailMover(Database):
                             # construct a new filename, composed of a made-up ID and the flags part
                             # of the original filename.
             basename = str(uuid.uuid1()) + flagpart
-        return os.path.join(destination, basename)
+        return os.path.join(destination, submaildir, basename)
 
     def move(self, maildir, rules):
         '''
@@ -54,7 +55,7 @@ class MailMover(Database):
         to_delete_fnames = []
         moved = False
         for query in rules.keys():
-            destination = '{}/{}/cur/'.format(self.db_path, rules[query])
+            destination = '{}/{}/'.format(self.db_path, rules[query])
             main_query = self.query.format(
                 folder=maildir.replace("\"", "\\\""), subquery=query)
             logging.debug("query: {}".format(main_query))

--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -33,20 +33,17 @@ class MailMover(Database):
         self.rename = rename
 
     def get_new_name(self, fname, destination):
+        basename = os.path.basename(fname)
         if self.rename:
-            parts = os.path.basename(fname).split(':')
+            parts = basename.split(':')
             if len(parts) > 1:
                 flagpart = ':' + parts[-1]
             else:
                 flagpart = ''
-            return os.path.join(
-                            destination,
                             # construct a new filename, composed of a made-up ID and the flags part
                             # of the original filename.
-                            str(uuid.uuid1()) + flagpart
-                        )
-        else:
-            return destination
+            basename = str(uuid.uuid1()) + flagpart
+        return os.path.join(destination, basename)
 
     def move(self, maildir, rules):
         '''


### PR DESCRIPTION
So here is a suggestion to fix #196.
A fix to #190 could go on top easily (although it is unrelated). In fact, there is currently a mix of "treating paths right" (`os.path`...) and working with `/` by hand which could use some sanitizing.