### PR TITLE
Use `db.find_message` in `Filter.commit`

### DIFF
--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -103,16 +103,15 @@ class Filter(object):
             db = self.database.open(rw=True)
 
             for message_id in dirty_messages:
-                messages = notmuch.Query(db, 'id:"%s"' % message_id).search_messages()
+                message = db.find_message(message_id)
 
-                for message in messages:
-                    if message_id in self._flush_tags:
-                        message.remove_all_tags()
+                if message_id in self._flush_tags:
+                    message.remove_all_tags()
 
-                    for tag in self._add_tags.get(message_id, []):
-                        message.add_tag(tag)
+                for tag in self._add_tags.get(message_id, []):
+                    message.add_tag(tag)
 
-                    for tag in self._remove_tags.get(message_id, []):
-                        message.remove_tag(tag)
+                for tag in self._remove_tags.get(message_id, []):
+                    message.remove_tag(tag)
 
         self.flush_changes()


### PR DESCRIPTION
Use `notmuch.Database.find_message` instead of `notmuch.Query` as a more idiomatic way to get a message and to avoid problems with escaping double quotes.

---

A little background... I tried using `afew` a few months back, but ran into crashing bugs with `InboxFilter`, I've spent some time this morning trying to get to the bottom of them.

Basically some of my messages have `id` tags with a `"` in them. I tried escaping the double quote, but there isn't that much info on it, I think you're supposed to repeat them (e.g. `"` becomes `""`). However using [`Database.find_message`][find_message] is a better solution, and may even have better performance.

[find_message]: https://notmuch.readthedocs.io/projects/notmuch-python/en/latest/database.html#notmuch.Database.find_message