### PR TITLE
Drop Python 2 support from docs, remove Python 2 hacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Features
 * can move mails based on arbitrary notmuch queries, so your sorting
   may show on your traditional mail client (well, almost ;))
 * has a ``--dry-run`` mode for safe testing
-* works with python 2.7, 3.1 and 3.2
+* works with python 3.4+
 
 
 

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -128,9 +128,7 @@ def main():
     logging.basicConfig(level=loglevel)
 
     sys.path.insert(0, user_config_dir)
-    # py2.7 compat hack
-    glob_pattern = b'*.py' if sys.version_info[0] == 2 else '*.py'
-    for file_name in glob.glob1(user_config_dir,  glob_pattern):
+    for file_name in glob.glob1(user_config_dir, '*.py'):
         logging.info('Importing user filter %r' % (file_name, ))
         __import__(file_name[:-3], level=0)
 

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -91,6 +91,9 @@ options_group.add_argument(
 
 
 def main():
+    if sys.version_info < (3,4):
+        sys.exit("Python 3.4 or later is required.")
+
     args = parser.parse_args()
 
     no_actions = len(filter_compat(None, (

--- a/afew/filters/__init__.py
+++ b/afew/filters/__init__.py
@@ -4,12 +4,9 @@
 
 from __future__ import print_function, absolute_import, unicode_literals
 
-import sys
 import os
 import glob
 
 __all__ = list(filename[:-3]
-               for filename in glob.glob1(os.path.dirname(__file__),
-                                          # py2.7 compat hack
-                                          b'*.py' if sys.version_info[0] == 2 else '*.py')
+               for filename in glob.glob1(os.path.dirname(__file__), '*.py')
                if filename is not '__init__.py')

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Requirements
 ------------
 
-afew works with python 2.7, 3.1 and 3.2, and requires notmuch and its python bindings.
+afew works with python 3.4+, and requires notmuch and its python bindings.
 On Debian/Ubuntu systems you can install these by doing:
 
 .. code-block:: sh

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>


### PR DESCRIPTION
We already encourage running afew with Python 3 for some time now, and there's some weird bugs when running with Python 2 (#180, #181).

Given Python 3 is available almost everywhere too, let's get rid of python 2 and hacks present in the codebase.

cc @varac