### PR TITLE
Split folders and preserve quoted names

### DIFF
--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -7,6 +7,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 import os
 import re
 import collections
+import shlex
 
 from .configparser import SafeConfigParser
 from afew.FilterRegistry import all_filters
@@ -68,7 +69,7 @@ def get_mail_move_rules():
     if settings.has_option(mail_mover_section, 'folders'):
         all_rules = collections.OrderedDict()
 
-        for folder in settings.get(mail_mover_section, 'folders').split():
+        for folder in shlex.split(settings.get(mail_mover_section, 'folders')):
             if settings.has_option(mail_mover_section, folder):
                 rules = collections.OrderedDict()
                 raw_rules = re.findall(rule_pattern,

--- a/docs/source/move_mode.rst
+++ b/docs/source/move_mode.rst
@@ -22,12 +22,13 @@ Below we explain what each bit of this means.
 Rules
 -----
 
-First you need to specify which folders should be checked for mails that are to
-be moved (as a whitespace separated list):
+First you need to specify which folders should be checked for mails
+that are to be moved (as a whitespace separated list). Folder names
+containing whitespace need to be quoted:
 
 .. code-block:: ini
 
-    folders = INBOX Junk
+    folders = INBOX Junk "Sent Mail"
 
 Then you have to specify rules that define move actions of the form
 


### PR DESCRIPTION
If a folder in the `MailMover` section includes a
space (e.g. `[Gmail].Sent Mail`) there is currently not way to quote
the folder name such as to preserver the space in it. This change
replaces the standard `split()` function with one that understands
quotes. For the above example, the following config entry works:

        folders = "[Gmail].Sent Mail" other_folder

Fixes: #97

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>