### PR TITLE
add MAILDIR as fallback for database location

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@ Better support for whitespaces and quotes in folder names
   Previously, afew failed with folders containing quotes or namespaces. These
   are now properly escaped internally.
 
+Support `MAILDIR` as fallback for database location
+
+  In addition to reading notmuch databse location from notmuch config, afew now
+  supports reading from the `MAILDIR` environment variable, like notmuch CLI
+  does, too.
+
 afew 1.3.0 (2018-02-06)
 =======================
 

--- a/afew/Database.py
+++ b/afew/Database.py
@@ -20,7 +20,7 @@ class Database(object):
     def __init__(self):
         self.db_path = notmuch_settings.get('database', 'path',
                                             fallback=os.environ.get('MAILDIR',
-                                                                    '%s/mail' % os.environ.get('HOME')))
+                                                                    '{}/mail'.format(os.environ.get('HOME'))))
         self.handle = None
 
     def __enter__(self):

--- a/afew/Database.py
+++ b/afew/Database.py
@@ -7,7 +7,6 @@ from __future__ import print_function, absolute_import, unicode_literals
 import os
 import time
 import logging
-import configparser
 
 import notmuch
 
@@ -21,7 +20,7 @@ class Database(object):
     def __init__(self):
         self.db_path = notmuch_settings.get('database', 'path',
                                             fallback=os.environ.get('MAILDIR',
-                                                                    configparser._UNSET))
+                                                                    '%s/mail' % os.environ.get('HOME')))
         self.handle = None
 
     def __enter__(self):

--- a/afew/Database.py
+++ b/afew/Database.py
@@ -4,8 +4,10 @@
 
 from __future__ import print_function, absolute_import, unicode_literals
 
+import os
 import time
 import logging
+import configparser
 
 import notmuch
 
@@ -17,7 +19,9 @@ class Database(object):
     '''
 
     def __init__(self):
-        self.db_path = notmuch_settings.get('database', 'path')
+        self.db_path = notmuch_settings.get('database', 'path',
+                                            fallback=os.environ.get('MAILDIR',
+                                                                    configparser._UNSET))
         self.handle = None
 
     def __enter__(self):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,6 +19,8 @@ make sure that `~/.notmuch-config` contains:
     [new]
     tags=new
 
+afew reads the notmuch database location from notmuch config. When no database path is set in notmuch config, afew uses the `MAILDIR` environment variable when set, or `$HOME/mail` as a fallback, like notmuch CLI does.
+
 Filter Configuration
 --------------------
 


### PR DESCRIPTION
Notmuch cli uses the MAILDIR environment variable as a default when no database path is configured in notmuch config. This adds the same behaviour to afew.

```
       database.path
              The top-level directory where your mail currently exists and to where mail will be delivered in the future. Files
              should be individual email messages. Notmuch will store its database within a sub-directory of the  path  config‐
              ured here named .notmuch.

              Default: $MAILDIR variable if set, otherwise $HOME/mail.
```