### PR TITLE
MailMover: escape mail folder name with double quotes

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -5,7 +5,6 @@
 import notmuch
 import logging
 import os, shutil
-import shlex
 from subprocess import check_call, CalledProcessError
 
 from .Database import Database
@@ -23,7 +22,7 @@ class MailMover(Database):
     def __init__(self, max_age=0, rename = False, dry_run=False):
         super(MailMover, self).__init__()
         self.db = notmuch.Database(self.db_path)
-        self.query = 'folder:{folder} AND {subquery}'
+        self.query = 'folder:"{folder}" AND {subquery}'
         if max_age:
             days = timedelta(int(max_age))
             start = date.today() - days
@@ -55,7 +54,7 @@ class MailMover(Database):
         for query in rules.keys():
             destination = '{}/{}/cur/'.format(self.db_path, rules[query])
             main_query = self.query.format(
-                folder=shlex.quote(maildir), subquery=query)
+                folder=maildir.replace("\"", "\\\""), subquery=query)
             logging.debug("query: {}".format(main_query))
             messages = notmuch.Query(self.db, main_query).search_messages()
             for message in messages:


### PR DESCRIPTION
shlex.quote quoted with single quotes, which is not supported by
notmuch, so we have to quote and escape on our own

followup of https://github.com/afewmail/afew/pull/218#issuecomment-457832361

cc @nicolasbock 