### PR TITLE
ArchiveSentMailsFilter: fix to_transforms

### DIFF
--- a/afew/filters/ArchiveSentMailsFilter.py
+++ b/afew/filters/ArchiveSentMailsFilter.py
@@ -10,8 +10,8 @@ from ..NotmuchSettings import get_notmuch_new_tags
 class ArchiveSentMailsFilter(SentMailsFilter):
     message = 'Archiving all mails sent by myself to others'
 
-    def __init__(self, database, sent_tag=''):
-        super(ArchiveSentMailsFilter, self).__init__(database, sent_tag)
+    def __init__(self, database, sent_tag='', to_transforms=''):
+        super(ArchiveSentMailsFilter, self).__init__(database, sent_tag, to_transforms)
 
     def handle_message(self, message):
         super(ArchiveSentMailsFilter, self).handle_message(message)


### PR DESCRIPTION
This parameter was missing from the constructors signature, and not passed down properly.

fixes #207

cc @jefftemplon