### PR TITLE
Filter: let user remove "unread" or "read" tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,11 @@ Support relative path for database location
   parity, afew now supports the same methodology of prepending `$HOME/` if a
   relative path is provided.
 
+Support for removing unread and read tags in filters
+
+  In a filter rule, it was possible to add "unread" and "read" tags but
+  not to remove them.
+
 afew 1.3.0 (2018-02-06)
 =======================
 

--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -73,11 +73,6 @@ class Filter(object):
     def remove_tags(self, message, *tags):
         if tags:
             filtered_tags = list(tags)
-            try:
-                filtered_tags.remove('unread')
-                filtered_tags.remove('read')
-            except ValueError:
-                pass
             self.log.debug('Removing tags %s from id:%s' % (', '.join(filtered_tags),
                                                            message.get_message_id()))
             self._remove_tags[message.get_message_id()].update(filtered_tags)


### PR DESCRIPTION
If the users wants to do it with notmuch-tag, they can, so why
not with afew?

Closes https://github.com/afewmail/afew/issues/221