### PR TITLE
Add support for fallbacks and relative paths in same way as notmuch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,13 @@ Support `MAILDIR` as fallback for database location
   supports reading from the `MAILDIR` environment variable, like notmuch CLI
   does, too.
 
+Support relative path for database location
+
+  As of notmuch 0.28, a relative path may be provided for the database
+  location. notmuch prepends `$HOME/` to the relative path. For feature
+  parity, afew now supports the same methodology of prepending `$HOME/` if a
+  relative path is provided.
+
 afew 1.3.0 (2018-02-06)
 =======================
 

--- a/afew/Database.py
+++ b/afew/Database.py
@@ -18,15 +18,23 @@ class Database(object):
     '''
 
     def __init__(self):
-        self.db_path = notmuch_settings.get('database', 'path',
-                                            fallback=os.environ.get('MAILDIR',
-                                                                    '{}/mail'.format(os.environ.get('HOME'))))
+        self.db_path = self._calculate_db_path()
+        self.handle = None
+
+    def _calculate_db_path(self):
+        '''
+        Calculates the path to use for the database. Supports notmuch's
+        methodology including falling back to $MAILDIR or $HOME/mail if a path
+        is not specified and using $HOME/<path> if path is relative.
+        '''
+        default_path = os.environ.get('MAILDIR', '{}/mail'.format(os.environ.get('HOME')))
+        db_path = notmuch_settings.get('database', 'path', fallback=default_path)
 
         # If path is relative, notmuch prepends $HOME in front
-        if not os.path.isabs(self.db_path):
-            self.db_path = '{}/{}'.format(os.environ.get('HOME'), self.db_path)
+        if not os.path.isabs(db_path):
+            db_path = '{}/{}'.format(os.environ.get('HOME'), db_path)
 
-        self.handle = None
+        return db_path
 
     def __enter__(self):
         '''

--- a/afew/Database.py
+++ b/afew/Database.py
@@ -4,6 +4,7 @@
 
 from __future__ import print_function, absolute_import, unicode_literals
 
+import os
 import time
 import logging
 
@@ -17,7 +18,14 @@ class Database(object):
     '''
 
     def __init__(self):
-        self.db_path = notmuch_settings.get('database', 'path')
+        self.db_path = notmuch_settings.get('database', 'path',
+                                            fallback=os.environ.get('MAILDIR',
+                                                                    '{}/mail'.format(os.environ.get('HOME'))))
+
+        # If path is relative, notmuch prepends $HOME in front
+        if not os.path.isabs(self.db_path):
+            self.db_path = '{}/{}'.format(os.environ.get('HOME'), self.db_path)
+
         self.handle = None
 
     def __enter__(self):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,7 +19,11 @@ make sure that `~/.notmuch-config` contains:
     [new]
     tags=new
 
-afew reads the notmuch database location from notmuch config. When no database path is set in notmuch config, afew uses the `MAILDIR` environment variable when set, or `$HOME/mail` as a fallback, like notmuch CLI does.
+afew reads the notmuch database location from notmuch config. When no database
+path is set in notmuch config, afew uses the `MAILDIR` environment variable
+when set, or `$HOME/mail` as a fallback, like notmuch CLI does. If a relative
+path is provided, afew prepends `$HOME/` to the path in the same manner as
+notmuch, which was introduced in version 0.28 of notmuch.
 
 Filter Configuration
 --------------------


### PR DESCRIPTION
Resolves #232.

Similar to #219, but also adds support for relative paths in same way as notmuch.

The relative paths is a new feature of notmuch as of 0.28 released back in 2018. Not sure if there's a way to gate support for that by checking the notmuch version.