### PR TITLE
drop Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 language: python
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
 
 matrix:

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 * can move mails based on arbitrary notmuch queries, so your sorting
   may show on your traditional mail client (well, almost ;))
 * has a ``--dry-run`` mode for safe testing
-* works with python 3.4+
+* works with python 3.6+
 
 
 

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -95,8 +95,8 @@ options_group.add_argument(
 )
 
 def main():
-    if sys.version_info < (3,4):
-        sys.exit("Python 3.4 or later is required.")
+    if sys.version_info < (3,6):
+        sys.exit("Python 3.6 or later is required.")
 
     args = parser.parse_args()
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Requirements
 ------------
 
-afew works with python 3.4+, and requires notmuch and its python bindings.
+afew works with python 3.6+, and requires notmuch and its python bindings.
 On Debian/Ubuntu systems you can install these by doing:
 
 .. code-block:: sh


### PR DESCRIPTION
This allows to use some more recent Python features, and even Debian stable comes with 3.7 by now.