### PR TITLE
.travis.yml: fix 3.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-dist: trusty
 language: python
-python:
-  - "3.6"
-
 matrix:
   include:
+    - python: 3.6
+      dist: xenial
     - python: 3.7
       dist: xenial
 


### PR DESCRIPTION
For some reason, removing the other pythons from "python:" also got
travis to ignore the python: - "3.6" in there, so let's remove python:
alltogether, and use the matrix: include: syntax as we already do for
3.7.

cc @kyrias