### PR TITLE
tree-wide: remove coding: utf-8 headers

### DIFF
--- a/afew/Database.py
+++ b/afew/Database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/FilterRegistry.py
+++ b/afew/FilterRegistry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) dtk <dtk@gmx.de>
 

--- a/afew/NotmuchSettings.py
+++ b/afew/NotmuchSettings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/__init__.py
+++ b/afew/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/__main__.py
+++ b/afew/__main__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Lucas Hoffmann
 

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/configparser.py
+++ b/afew/configparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/files.py
+++ b/afew/files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/filters/ArchiveSentMailsFilter.py
+++ b/afew/filters/ArchiveSentMailsFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
@@ -6,6 +5,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 from ..filters.SentMailsFilter import SentMailsFilter
 from ..NotmuchSettings import get_notmuch_new_tags
+
 
 class ArchiveSentMailsFilter(SentMailsFilter):
     message = 'Archiving all mails sent by myself to others'

--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -1,4 +1,3 @@
-#  -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/filters/DKIMValidityFilter.py
+++ b/afew/filters/DKIMValidityFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Amadeusz Zolnowski <aidecoe@aidecoe.name>
 

--- a/afew/filters/DMARCReportInspectionFilter.py
+++ b/afew/filters/DMARCReportInspectionFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Amadeusz Zolnowski <aidecoe@aidecoe.name>
 

--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) dtk <dtk@gmx.de>
 

--- a/afew/filters/HeaderMatchingFilter.py
+++ b/afew/filters/HeaderMatchingFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) 2012 Justus Winter <4winter@informatik.uni-hamburg.de>
 # Copyright (c) 2013 Patrick Gerken <do3cc@patrick-gerken.de>

--- a/afew/filters/InboxFilter.py
+++ b/afew/filters/InboxFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 from __future__ import print_function, absolute_import, unicode_literals

--- a/afew/filters/KillThreadsFilter.py
+++ b/afew/filters/KillThreadsFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/filters/ListMailsFilter.py
+++ b/afew/filters/ListMailsFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
@@ -13,4 +12,3 @@ class ListMailsFilter(HeaderMatchingFilter):
     pattern = r"<(?P<list_id>[a-z0-9!#$%&'*+/=?^_`{|}~-]+)\."
     header = 'List-Id'
     tags = ['+lists', '+lists/{list_id}']
-

--- a/afew/filters/MeFilter.py
+++ b/afew/filters/MeFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Amadeusz Zolnowski <aidecoe@aidecoe.name>
 

--- a/afew/filters/PropagateTagsByRegexInThreadFilter.py
+++ b/afew/filters/PropagateTagsByRegexInThreadFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) Jens Neuhalfen <jens@neuhalfen.name>
 
 from __future__ import print_function, absolute_import, unicode_literals

--- a/afew/filters/PropagateTagsInThreadFilter.py
+++ b/afew/filters/PropagateTagsInThreadFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) Jens Neuhalfen <jens@neuhalfen.name>
 
 from __future__ import print_function, absolute_import, unicode_literals

--- a/afew/filters/SentMailsFilter.py
+++ b/afew/filters/SentMailsFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
@@ -36,7 +35,6 @@ class SentMailsFilter(Filter):
         if to_transforms:
             self.__email_to_tags = self.__build_email_to_tags(to_transforms)
 
-
     def handle_message(self, message):
         if self.sent_tag:
             self.add_tags(message, self.sent_tag)
@@ -47,7 +45,6 @@ class SentMailsFilter(Filter):
                     self.add_tags(message, tag)
                 else:
                     break
-
 
     def __build_email_to_tags(self, to_transforms):
         email_to_tags = dict()
@@ -62,14 +59,12 @@ class SentMailsFilter(Filter):
 
         return email_to_tags
 
-
     def __get_bare_email(self, email):
         if not '<' in email:
             return email
         else:
             match = self._bare_email_re.search(email)
             return match.group('email')
-
 
     def __pick_tags(self, email):
         if email in self.__email_to_tags:

--- a/afew/filters/SpamFilter.py
+++ b/afew/filters/SpamFilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/filters/__init__.py
+++ b/afew/filters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/main.py
+++ b/afew/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/afew/tests/test_settings.py
+++ b/afew/tests/test_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) 2013 Patrick Gerken <do3cc@patrick-gerken.de>
 

--- a/afew/utils.py
+++ b/afew/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) 2011 Justus Winter <4winter@informatik.uni-hamburg.de>
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 


### PR DESCRIPTION
They're a default in Python 3 anyways.