### PR TITLE
tree-wide: drop from __future__ imports

### DIFF
--- a/afew/Database.py
+++ b/afew/Database.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import os
 import time
 import logging

--- a/afew/FilterRegistry.py
+++ b/afew/FilterRegistry.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import pkg_resources
 
 

--- a/afew/NotmuchSettings.py
+++ b/afew/NotmuchSettings.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import os
 
 from .configparser import RawConfigParser

--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import os
 import re
 import collections

--- a/afew/__init__.py
+++ b/afew/__init__.py
@@ -1,5 +1,3 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
-
-from __future__ import print_function, absolute_import, unicode_literals

--- a/afew/__main__.py
+++ b/afew/__main__.py
@@ -2,7 +2,5 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Lucas Hoffmann
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from afew.commands import main
 main()

--- a/afew/commands.py
+++ b/afew/commands.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import glob
 import sys
 import time

--- a/afew/files.py
+++ b/afew/files.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import os
 import re
 import stat

--- a/afew/filters/ArchiveSentMailsFilter.py
+++ b/afew/filters/ArchiveSentMailsFilter.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from ..filters.SentMailsFilter import SentMailsFilter
 from ..NotmuchSettings import get_notmuch_new_tags
+
 
 class ArchiveSentMailsFilter(SentMailsFilter):
     message = 'Archiving all mails sent by myself to others'

--- a/afew/filters/BaseFilter.py
+++ b/afew/filters/BaseFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import collections
 import logging
 

--- a/afew/filters/DKIMValidityFilter.py
+++ b/afew/filters/DKIMValidityFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Amadeusz Zolnowski <aidecoe@aidecoe.name>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import dkim
 
 from .BaseFilter import Filter

--- a/afew/filters/DMARCReportInspectionFilter.py
+++ b/afew/filters/DMARCReportInspectionFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Amadeusz Zolnowski <aidecoe@aidecoe.name>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import re
 import tempfile
 import xml.etree.ElementTree as ET

--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) dtk <dtk@gmx.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from .BaseFilter import Filter
 from ..NotmuchSettings import notmuch_settings
 import re

--- a/afew/filters/HeaderMatchingFilter.py
+++ b/afew/filters/HeaderMatchingFilter.py
@@ -5,8 +5,6 @@
 # Copyright (c) 2013 Patrick Totzke <patricktotzke@gmail.com>
 # Copyright (c) 2014 Lars Kellogg-Stedman <lars@redhat.com>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from .BaseFilter import Filter
 
 import re

--- a/afew/filters/InboxFilter.py
+++ b/afew/filters/InboxFilter.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
-from __future__ import print_function, absolute_import, unicode_literals
 
 from .BaseFilter import Filter
 from ..NotmuchSettings import get_notmuch_new_tags, get_notmuch_new_query

--- a/afew/filters/KillThreadsFilter.py
+++ b/afew/filters/KillThreadsFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from .BaseFilter import Filter
 
 

--- a/afew/filters/ListMailsFilter.py
+++ b/afew/filters/ListMailsFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from .HeaderMatchingFilter import HeaderMatchingFilter
 
 

--- a/afew/filters/MeFilter.py
+++ b/afew/filters/MeFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Amadeusz Zolnowski <aidecoe@aidecoe.name>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import re
 
 from ..utils import filter_compat

--- a/afew/filters/PropagateTagsByRegexInThreadFilter.py
+++ b/afew/filters/PropagateTagsByRegexInThreadFilter.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Jens Neuhalfen <jens@neuhalfen.name>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import re
 from itertools import chain
 

--- a/afew/filters/PropagateTagsInThreadFilter.py
+++ b/afew/filters/PropagateTagsInThreadFilter.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Jens Neuhalfen <jens@neuhalfen.name>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from .BaseFilter import Filter
 
 

--- a/afew/filters/SentMailsFilter.py
+++ b/afew/filters/SentMailsFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import re
 
 from ..utils import filter_compat

--- a/afew/filters/SpamFilter.py
+++ b/afew/filters/SpamFilter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 from .HeaderMatchingFilter import HeaderMatchingFilter
 
 

--- a/afew/filters/__init__.py
+++ b/afew/filters/__init__.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import os
 import glob
 

--- a/afew/main.py
+++ b/afew/main.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import random
 import sys
 

--- a/afew/utils.py
+++ b/afew/utils.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-from __future__ import print_function, absolute_import, unicode_literals
-
 import codecs
 import re
 import sys


### PR DESCRIPTION
We're Python 3 only by now, so this can be dropped.