### PR TITLE
Python-3.8 compatibility

### DIFF
--- a/afew/commands.py
+++ b/afew/commands.py
@@ -96,18 +96,18 @@ def main():
 
     args = parser.parse_args()
 
-    no_actions = len(filter(None, (
+    no_actions = len(list(filter(None, (
         args.tag,
         args.watch,
         args.move_mails
-    )))
+    ))))
     if no_actions == 0:
         sys.exit('You need to specify an action')
     elif no_actions > 1:
         sys.exit('Please specify exactly one action')
 
-    no_query_modifiers = len(filter(None, (args.all,
-                                           args.new, args.query)))
+    no_query_modifiers = len(list(filter(None, (args.all,
+                                                args.new, args.query))))
     if no_query_modifiers == 0 and not args.watch \
             and not args.move_mails:
         sys.exit('You need to specify one of --new, --all or a query string')

--- a/afew/filters/__init__.py
+++ b/afew/filters/__init__.py
@@ -6,4 +6,4 @@ import glob
 
 __all__ = list(filename[:-3]
                for filename in glob.glob1(os.path.dirname(__file__), '*.py')
-               if filename is not '__init__.py')
+               if filename != '__init__.py')


### PR DESCRIPTION
Upon upgrading to python-3.8, I encountered these two issues, which are resolved in this PR.
```
TypeError: object of type 'filter' has no len()
```

```
/home/jed/src/afew/afew/filters/__init__.py:9: SyntaxWarning: "is not" with a literal. Did you mean "!="?                                                                                      
  if filename is not '__init__.py')         
```