### PR TITLE
Fix trailing ; in notmuch config breaking SentMailsFilter

### DIFF
--- a/afew/filters/MeFilter.py
+++ b/afew/filters/MeFilter.py
@@ -17,7 +17,7 @@ class MeFilter(Filter):
         my_addresses = set()
         my_addresses.add(notmuch_settings.get('user', 'primary_email'))
         if notmuch_settings.has_option('user', 'other_email'):
-            for other_email in notmuch_settings.get('user', 'other_email').split(';'):
+            for other_email in notmuch_settings.get_list('user', 'other_email'):
                 my_addresses.add(other_email)
 
         self.query = ' OR '.join('to:"%s"' % address

--- a/afew/filters/SentMailsFilter.py
+++ b/afew/filters/SentMailsFilter.py
@@ -18,8 +18,7 @@ class SentMailsFilter(Filter):
         my_addresses.add(notmuch_settings.get('user', 'primary_email'))
         if notmuch_settings.has_option('user', 'other_email'):
             for other_email in notmuch_settings.get('user', 'other_email').split(';'):
-                if other_email:
-                    my_addresses.add(other_email)
+                my_addresses.add(other_email)
 
         self.query = (
                 '(' +

--- a/afew/filters/SentMailsFilter.py
+++ b/afew/filters/SentMailsFilter.py
@@ -18,7 +18,8 @@ class SentMailsFilter(Filter):
         my_addresses.add(notmuch_settings.get('user', 'primary_email'))
         if notmuch_settings.has_option('user', 'other_email'):
             for other_email in notmuch_settings.get('user', 'other_email').split(';'):
-                my_addresses.add(other_email)
+                if other_email:
+                    my_addresses.add(other_email)
 
         self.query = (
                 '(' +

--- a/afew/filters/SentMailsFilter.py
+++ b/afew/filters/SentMailsFilter.py
@@ -17,7 +17,7 @@ class SentMailsFilter(Filter):
         my_addresses = set()
         my_addresses.add(notmuch_settings.get('user', 'primary_email'))
         if notmuch_settings.has_option('user', 'other_email'):
-            for other_email in notmuch_settings.get('user', 'other_email').split(';'):
+            for other_email in notmuch_settings.get_list('user', 'other_email'):
                 my_addresses.add(other_email)
 
         self.query = (


### PR DESCRIPTION
The trailing semicolon resulted in the string split containing an empty string. When the notmuch
query is built later on this results in no messages being matched by the filter.

e.g.  in notmuch-config
```
primary_email=primary@domain.com
other_email=secondary@domain.com;tertiary@domain.com;
```

This fix ensures that the empty string is not added to the `my_addresses` set.

A potentially better fix would be to ensure that `notmuch_settings.get()` removes trailing ;

This fixes #265   