### PR TITLE
[Bugfix] FolderNameFilter doesn't work on relative paths

### DIFF
--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -16,6 +16,8 @@ class FolderNameFilter(Filter):
 
         self.__filename_pattern = '{mail_root}/(?P<maildirs>.*)/(cur|new)/[^/]+'.format(
             mail_root=notmuch_settings.get('database', 'path').rstrip('/'))
+        if not(self.__filename_pattern.startswith("/")):
+            self.__filename_pattern = os.path.expanduser("~/"+self.__filename_pattern)
         self.__folder_explicit_list = set(shlex.split(folder_explicit_list))
         self.__folder_blacklist = set(folder_blacklist.split())
         self.__folder_transforms = self.__parse_transforms(folder_transforms)


### PR DESCRIPTION
You can specify as mail root mail/foo instead of /home/username/mail/foo in notmuch, but when doing so afew can't match the folder structure.
My fix checks if it starts with a / (fullpath) and if not adds ~.
An alternative fix would be to expand the matching with ".*", but that would be prone to breaking when your username is the same as the maildir name (e.g. /home/mail/mail)