### PR TITLE
Allow quoted folder names in folder_blacklist

### DIFF
--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -17,7 +17,7 @@ class FolderNameFilter(Filter):
         self.__filename_pattern = '{mail_root}/(?P<maildirs>.*)/(cur|new)/[^/]+'.format(
             mail_root=notmuch_settings.get('database', 'path').rstrip('/'))
         self.__folder_explicit_list = set(shlex.split(folder_explicit_list))
-        self.__folder_blacklist = set(folder_blacklist.split())
+        self.__folder_blacklist = set(shelx.split(folder_blacklist))
         self.__folder_transforms = self.__parse_transforms(folder_transforms)
         self.__folder_lowercases = folder_lowercases != ''
         self.__maildir_separator = maildir_separator


### PR DESCRIPTION
Update `FolderNameFilter.py` to allow for quoted folder names in `folder_blacklist`.

Before, setting
```
[FolderNameFilter]
folder_blacklist = "Sent Items" Archive inbox
```
would parse `folder_blacklist` to 
```
{'inbox', '"Sent', 'Archive', 'Items"'}
```

With the proposed change `folder_blacklist` would now parse to
```
{'Sent Items', 'Archive', 'inbox'}  
```