### PR TITLE
build.yml: fix syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Upload to TestPyPI
         uses: pypa/gh-action-pypi-publish@186232109eade3d22bfe1bca29ac9a1312598511
-        if: github.ref == "master"
+        if: ${{github.ref == 'master'}}
         with:
           user: __token__
           password: ${{ secrets.testpypi_token }}


### PR DESCRIPTION
Turns out, if there's a syntax error in your GitHub Actions file, GitHub
just silently ignores it alltogether (or at least doesn't show the error
very prominently), which caused
https://github.com/afewmail/afew/pull/279 to be merged.