### PR TITLE
add release.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,3 @@ jobs:
           source ./env/bin/activate
           pip install sphinx
           python setup.py build_sphinx -b html,man
-  release:
-    needs: [build-ubuntu]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Upload to TestPyPI
-        uses: pypa/gh-action-pypi-publish@186232109eade3d22bfe1bca29ac9a1312598511
-        if: ${{github.ref == 'refs/heads/master'}}
-        with:
-          user: __token__
-          password: ${{ secrets.testpypi_token }}
-          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    needs: [build-ubuntu]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools setuptools_scm wheel twine
+      - name: Build and publish (testpypi)
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.testpypi_token }}
+          TWINE_REPOSITORY: testpypi
+        run: |
+          python setup.py sdist
+          twine upload dist/*


### PR DESCRIPTION
release.yml: run on published releases, invoke twine manually
    
This now runs on all published releases, and invokes
`python setup.py sdist` and `twine upload` manually - the
gh-action-pypi-publish was a bit too magic for my taste and didn't work
properly.
   
This runs only on testpypi on purpose - we'll point it to the real PyPi
once this has proven to work.