### PR TITLE
HeaderMatchingFilter: do not convert user supplied tags

### DIFF
--- a/afew/filters/HeaderMatchingFilter.py
+++ b/afew/filters/HeaderMatchingFilter.py
@@ -25,7 +25,7 @@ class HeaderMatchingFilter(Filter):
                 value = message.get_header(self.header)
                 match = self.pattern.search(value)
                 if match:
-                    sub = (lambda tag:
-                           tag.format(**match.groupdict()).lower())
+                    tagdict = {k: v.lower() for k, v in match.groupdict().items()}
+                    sub = (lambda tag: tag.format(**tagdict))
                     self.remove_tags(message, *map(sub, self._tags_to_remove))
                     self.add_tags(message, *map(sub, self._tags_to_add))


### PR DESCRIPTION
fe71b20 ("lowercase generated tag names", 2014-02-18) made the
HeaderMatchingFilter convert tags to lower case. While this may make
sense for tags which are generated from header values it certainly does
not for tags which the user specified verbatim in their config.

So, only convert the values resulting from a pattern match.