### PR TITLE
Get notmuch database path using Database wrapper

### DIFF
--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -2,7 +2,6 @@
 # Copyright (c) dtk <dtk@gmx.de>
 
 from afew.filters.BaseFilter import Filter
-from afew.NotmuchSettings import notmuch_settings
 import re
 import shlex
 
@@ -15,7 +14,7 @@ class FolderNameFilter(Filter):
         super().__init__(database)
 
         self.__filename_pattern = '{mail_root}/(?P<maildirs>.*)/(cur|new)/[^/]+'.format(
-            mail_root=notmuch_settings.get('database', 'path').rstrip('/'))
+            mail_root=database.db_path.rstrip('/'))
         self.__folder_explicit_list = set(shlex.split(folder_explicit_list))
         self.__folder_blacklist = set(shlex.split(folder_blacklist))
         self.__folder_transforms = self.__parse_transforms(folder_transforms)


### PR DESCRIPTION
It fixes #303 and closes #267, allowing FolderNameFilter to work with
relative path in database.path of notmuch config file.