### PR TITLE
Upgrade python support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: Build (Python ${{ matrix.python }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: flake8 lint
         run: |
           source ./env/bin/activate
-          flake8 --ignore=E501 afew/
+          flake8 --ignore=E501,W504 afew/
       - name: Tests
         run: |
           source ./env/bin/activate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: Build (Python ${{ matrix.python }})
     runs-on: ubuntu-18.04
     steps:

--- a/afew/files.py
+++ b/afew/files.py
@@ -23,7 +23,7 @@ class EventHandler(pyinotify.ProcessEvent):
         self.database = database
         super().__init__()
 
-    ignore_re = re.compile('(/xapian/.*(base.|tmp)$)|(\.lock$)|(/dovecot)')
+    ignore_re = re.compile(r'(/xapian/.*(base.|tmp)$)|(\.lock$)|(/dovecot)')
 
     def process_IN_DELETE(self, event):
         if self.ignore_re.search(event.pathname):


### PR DESCRIPTION
Hey,
To be able to upgrade python version matrix in the runner:
* Remove python-3.6
* Add python-3.10
* Bump ubuntu to latest stable 20.04
* A few flake8 upgrades

I think it fine, but if it would be better with an other on top of it (if you can @flokli).