### PR TITLE
DMARC Filter: allow to define subject regexp

### DIFF
--- a/afew/filters/DMARCReportInspectionFilter.py
+++ b/afew/filters/DMARCReportInspectionFilter.py
@@ -118,6 +118,16 @@ def read_auth_results(document):
 class DMARCReportInspectionFilter(Filter):
     """
     Inspect DMARC reports for DKIM and SPF status.
+
+    Config:
+
+    [DMARCReportInspectionFilter]
+    dkim_ok_tag = "dmarc/dkim-ok"
+    dkim_fail_tag = "dmarc/dkim-fail"
+    spf_ok_tag = "dmarc/spf-ok"
+    spf_fail_tag = "dmarc/spf-fail"
+    subject_regexp = "^report domain:"
+
     """
     def __init__(self,                     # pylint: disable=too-many-arguments
                  database,

--- a/afew/filters/DMARCReportInspectionFilter.py
+++ b/afew/filters/DMARCReportInspectionFilter.py
@@ -124,11 +124,12 @@ class DMARCReportInspectionFilter(Filter):
                  dkim_ok_tag='dmarc/dkim-ok',
                  dkim_fail_tag='dmarc/dkim-fail',
                  spf_ok_tag='dmarc/spf-ok',
-                 spf_fail_tag='dmarc/spf-fail'):
+                 spf_fail_tag='dmarc/spf-fail',
+                 subject_regexp=r'^report domain:'):
         super().__init__(database)
         self.dkim_tag = {True: dkim_ok_tag, False: dkim_fail_tag}
         self.spf_tag = {True: spf_ok_tag, False: spf_fail_tag}
-        self.dmarc_subject = re.compile(r'^report domain:',
+        self.dmarc_subject = re.compile(subject_regexp,
                                         flags=re.IGNORECASE)
         self.log = logging.getLogger('{}.{}'.format(
             self.__module__, self.__class__.__name__))


### PR DESCRIPTION
Some DMARC report mail subject have a prefix before "Dmarc Report" in
the subject and are not checked by the plugin. This commit allows the
user to define the suject regexp in the config file.
