### PR TITLE
docs: Fix HeaderMatchingFilter example

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -145,7 +145,7 @@ Some examples are:
 
     [HeaderMatchingFilter.3]
     header = X-Redmine-Project
-    pattern = (?P<project>.*)
+    pattern = (?P<project>.+)
     tags = +redmine;+{project}
 
 SpamFilter and ListMailsFilter are implemented using HeaderMatchingFilter, and are


### PR DESCRIPTION
The example should tag emails from Redmine with two tags: a fixed "redmine" and a dynamic one based on the project name. However, the configuration does something different: It tags *ALL* emails with the "redmine" tag and additionally tags emails with the "X-Redmine-Project" header with its content. The reason for tagging all emails is that a missing header is considered having an empty value and the pattern matches an empty string.

The fix is to ensure that the pattern does not match an empty string.