### PR TITLE
add 'send and archive' option to ArchiveSentMailsFilter

### DIFF
--- a/afew/filters/ArchiveSentMailsFilter.py
+++ b/afew/filters/ArchiveSentMailsFilter.py
@@ -8,9 +8,16 @@ from afew.NotmuchSettings import get_notmuch_new_tags
 class ArchiveSentMailsFilter(SentMailsFilter):
     message = 'Archiving all mails sent by myself to others'
 
-    def __init__(self, database, sent_tag='', to_transforms=''):
+    def __init__(self, database, sent_tag='', to_transforms='', archive_thread=False):
         super().__init__(database, sent_tag)
+        self.archive_thread = archive_thread
 
     def handle_message(self, message):
         super().handle_message(message)
         self.remove_tags(message, *get_notmuch_new_tags())
+        # Reply and Archive: remove inbox tag from thread when replying
+        if self.archive_thread:
+            threadquery = f'thread:{message.get_thread_id()} and tag:inbox'
+            inbox_in_thread = self.database.get_messages(threadquery)
+            for msg in inbox_in_thread:
+                self.remove_tags(msg, 'inbox')

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -23,6 +23,13 @@ It extends `SentMailsFilter` with the following feature:
  * Emails filtered by this filter have the **new** tag removed, so will not have
    the **inbox** tag added by the InboxFilter.
 
+In addition the SentMailsFilter settings, you can use:
+
+* archive_thread = <True|False> (default: False)
+  * When True, the inbox tag will be removed from the thread containing the sent
+    mail. (like the gmail 'Send and Archive' function)
+  * Useful for those who like a clean inbox
+
 DKIMValidityFilter
 ------------------
 


### PR DESCRIPTION
Inspired by the gmail 'Send and Archive' function. When enabled, the thread containing the sent message has its inbox tag removed. Useful for those who like a clean inbox.