### PR TITLE
FolderNameFilter: allow multiple tags per folder

### DIFF
--- a/afew/filters/FolderNameFilter.py
+++ b/afew/filters/FolderNameFilter.py
@@ -54,7 +54,7 @@ class FolderNameFilter(Filter):
         transformations = set()
         for folder in folders:
             if folder in self.__folder_transforms:
-                transformations.add(self.__folder_transforms[folder])
+                transformations.update(self.__folder_transforms[folder])
             else:
                 transformations.add(folder)
         if self.__folder_lowercases:
@@ -71,5 +71,8 @@ class FolderNameFilter(Filter):
         transformations = dict()
         for rule in shlex.split(transformation_description):
             folder, tag = rule.split(':')
-            transformations[folder] = tag
+            try:
+                transformations[folder].add(tag)
+            except KeyError:
+                transformations[folder] = set([tag])
         return transformations


### PR DESCRIPTION
So far, the last entry wins when a folder is specified multiple times as a folder transform. The reason is that the folder name is a key in a dict whose values are tags. On the other hand, if a message has copies in several folders then all these rules apply.

Change (fix?) afew's FolderNameFilter so that multiple transforms for the same folder lead to multiple tags being added. Technically, this is done by using sets as values in the transform dict.

In the future, we might think about implementing notmuch-tag style notation (with the obvious quoting issues).