### PR TITLE
Replace logging.warn usage with logging.warning

### DIFF
--- a/afew/MailMover.py
+++ b/afew/MailMover.py
@@ -80,7 +80,7 @@ class MailMover(Database):
                         shutil.copy2(fname, self.get_new_name(fname, destination))
                         to_delete_fnames.append(fname)
                     except shutil.SameFileError:
-                        logging.warn("trying to move '{}' onto itself".format(fname))
+                        logging.warning("trying to move '{}' onto itself".format(fname))
                         continue
                     except shutil.Error as e:
                         # this is ugly, but shutil does not provide more

--- a/afew/files.py
+++ b/afew/files.py
@@ -46,17 +46,17 @@ class EventHandler(pyinotify.ProcessEvent):
                     filter_.run('id:"{}"'.format(message.get_message_id()))
                     filter_.commit(self.options.dry_run)
                 except Exception as e:
-                    logging.warn('Error processing mail with filter {!r}: {}'.format(filter_.message, e))
+                    logging.warning('Error processing mail with filter {!r}: {}'.format(filter_.message, e))
 
         try:
             self.database.add_message(event.pathname,
                                       sync_maildir_flags=True,
                                       new_mail_handler=new_mail)
         except notmuch.FileError as e:
-            logging.warn('Error opening mail file: {}'.format(e))
+            logging.warning('Error opening mail file: {}'.format(e))
             return
         except notmuch.FileNotEmailError as e:
-            logging.warn('File does not look like an email: {}'.format(e))
+            logging.warning('File does not look like an email: {}'.format(e))
             return
         else:
             if src_pathname:


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.

https://docs.python.org/3.12/library/logging.html#logging.Logger.warning