### PR TITLE
Documentation: Fix malformed quoting in the examples in the configuration doc

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -146,23 +146,23 @@ Here are a few more example filters from github dotfiles:
 .. code-block:: ini
 
     [Filter.1]
-    query = 'sicsa-students@sicsa.ac.uk'
+    query = sicsa-students@sicsa.ac.uk
     tags = +sicsa
     message = sicsa
 
     [Filter.2]
-    query = 'from:foosoc.ed@gmail.com OR from:GT Silber OR from:lizzie.brough@eusa.ed.ac.uk'
+    query = from:foosoc.ed@gmail.com OR from:GT Silber OR from:lizzie.brough@eusa.ed.ac.uk
     tags = +soc;+foo
     message = foosoc
 
     [Filter.3]
-    query = 'folder:gmail/G+'
+    query = folder:gmail/G+
     tags = +G+
     message = gmail spam
 
     # skip inbox
     [Filter.6]
-    query = 'to:notmuch@notmuchmail.org AND (subject:emacs OR subject:elisp OR "(defun" OR "(setq" OR PATCH)'
+    query = to:notmuch@notmuchmail.org AND (subject:emacs OR subject:elisp OR "(defun" OR "(setq" OR PATCH)
     tags = -new
     message = notmuch emacs stuff
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -7,6 +7,9 @@ Configuration File
 Customization of tag filters takes place in afew's config file in
 `~/.config/afew/config`.
 
+The format is similar to what's found in Microsoft Windows INI files.
+Note values should not be quoted.
+
 NotMuch Config
 --------------
 


### PR DESCRIPTION
When trying to follow the examples in [the configuration documentation](https://afew.readthedocs.io/en/latest/configuration.html#more-filter-examples), I noticed that the queries are quoted, even though they should not be.

I tested this behaviour with Filter.3, which does not produce the expected results due to the quoting.

I assume that the same holds for the others as well. 
If not, please let me know so I can address this.