### PR TITLE
Fix settings file reading method in Settings.py

### DIFF
--- a/afew/Settings.py
+++ b/afew/Settings.py
@@ -18,7 +18,7 @@ settings = ConfigParser()
 # preserve the capitalization of the keys.
 settings.optionxform = str
 
-settings.readfp(open(os.path.join(os.path.dirname(__file__), 'defaults', 'afew.config')))
+settings.read_file(open(os.path.join(os.path.dirname(__file__), 'defaults', 'afew.config')))
 settings.read(os.path.join(user_config_dir, 'config'))
 
 # All the values for keys listed here are interpreted as ;-delimited lists


### PR DESCRIPTION
- Updated method from `readfp` to `read_file` for compatibility with Python 3.
- No change in functionality; improves code compliance with current Python standards.

Should, in part, fix #341 and #346 (notmuch python bindings shoulb be updated, too) 