### PR TITLE
Typo on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Its basic task is to provide automatic tagging each time new mail is registered
 with notmuch. In a classic setup, you might call it after 'notmuch new' in an
 offlineimap post sync hook.
 
-It can do basic thing such as adding tags based on email headers or maildir
+It can do basic things such as adding tags based on email headers or maildir
 folders, handling killed threads and spam.
 
 In move mode, afew will move mails between maildir folders according to


### PR DESCRIPTION
Changed word "thing" to "things" as it should be plural.
Closes #356 

Modification:

<img width="1183" alt="Screenshot 2025-05-14 at 18 10 57" src="https://github.com/user-attachments/assets/6ced6c91-582e-4dd9-b81a-ff9dc68e0ebf" />
