### PR TITLE
Fix deprecations

### DIFF
--- a/afew/commands.py
+++ b/afew/commands.py
@@ -5,6 +5,7 @@ import glob
 import sys
 import logging
 import argparse
+import os
 
 from afew.Database import Database
 from afew.main import main as inner_main
@@ -131,9 +132,9 @@ def main():
     logging.basicConfig(level=loglevel)
 
     sys.path.insert(0, user_config_dir)
-    for file_name in glob.glob1(user_config_dir, '*.py'):
+    for file_name in glob.glob(os.path.join(user_config_dir, '*.py')):
         logging.info('Importing user filter %r' % (file_name,))
-        __import__(file_name[:-3], level=0)
+        __import__(os.path.basename(file_name)[:-3], level=0)
 
     if args.move_mails:
         args.mail_move_rules = get_mail_move_rules()

--- a/afew/filters/__init__.py
+++ b/afew/filters/__init__.py
@@ -5,5 +5,5 @@ import os
 import glob
 
 __all__ = list(filename[:-3]
-               for filename in glob.glob1(os.path.dirname(__file__), '*.py')
+               for filename in glob.glob(os.path.join(os.path.dirname(__file__), '*.py'))
                if filename != '__init__.py')


### PR DESCRIPTION
- Use `importlib.metadata` instead of `pkg_resources` as the latter has been deprecated and is set to be removed by end of 2025: https://github.com/pypa/setuptools/issues/3085
This fixes: https://github.com/afewmail/afew/issues/360
- Change `glob.glob1` call as its use has been deprecated in python 3.13+: https://github.com/python/cpython/issues/117337
