### PR TITLE
Migrate from deprecated pkg_resources to importlib.metadata

### DIFF
--- a/afew/FilterRegistry.py
+++ b/afew/FilterRegistry.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: ISC
 # Copyright (c) Justus Winter <4winter@informatik.uni-hamburg.de>
 
-import pkg_resources
+import sys
+from importlib.metadata import entry_points
 
 RAISEIT = object()
 
@@ -51,7 +52,13 @@ class FilterRegistry:
         return self.filter.items()
 
 
-all_filters = FilterRegistry(pkg_resources.iter_entry_points('afew.filter'))
+# Python 3.10+ uses entry_points(group=...), Python 3.9 uses entry_points()[group]
+if sys.version_info >= (3, 10):
+    filter_entry_points = entry_points(group='afew.filter')
+else:
+    filter_entry_points = entry_points().get('afew.filter', [])
+
+all_filters = FilterRegistry(filter_entry_points)
 
 
 def register_filter(klass):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 
 import sys
 import os
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -74,7 +74,7 @@ pretended_version = os.environ.get('SETUPTOOLS_SCM_PRETEND_VERSION')
 if pretended_version:
     release = pretended_version
 else:
-    release = get_distribution('afew').version
+    release = version('afew')
 # The X.Y.Z version.
 version = '.'.join(release.split('.')[:3])
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     license="ISC",
     long_description=long_description,
     long_description_content_type="text/x-rst",
+    python_requires='>=3.9',
     setup_requires=['setuptools_scm'],
     packages=find_packages(),
     test_suite='afew.tests',


### PR DESCRIPTION
The pkg_resources module is deprecated and slated for removal in setuptools 81 (as early as 2025-11-30). This change eliminates UserWarning messages during afew execution by using the modern importlib.metadata API, which has been available since Python 3.8.
Also adds python_requires='>=3.9' to formally declare the minimum version after dropping Python 3.8 support in commit 2a22e7f.