### PR TITLE
NotmuchSettings: add support for profiles and XDG locations

### DIFF
--- a/afew/NotmuchSettings.py
+++ b/afew/NotmuchSettings.py
@@ -8,19 +8,32 @@ from afew.configparser import RawConfigParser
 notmuch_settings = RawConfigParser()
 
 
-def read_notmuch_settings(path=None):
-    if path is None:
-        path = os.environ.get('NOTMUCH_CONFIG', os.path.expanduser('~/.notmuch-config'))
+def _notmuch_config_path(path=None):
+    path = os.environ.get("NOTMUCH_CONFIG", path)
+    if path is not None:
+        return path
+    profile = os.environ.get("NOTMUCH_PROFILE", "default")
+    xdg_conf = os.path.join(
+        os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+        "notmuch",
+        profile,
+        "config",
+    )
+    if os.path.exists(xdg_conf):
+        return xdg_conf
+    if profile == "default":
+        return os.path.expanduser("~/.notmuch-config")
+    else:
+        return os.path.expanduser(f"~/.notmuch-config.{profile}")
 
-    with open(path) as fp:
+
+def read_notmuch_settings(path=None):
+    with open(_notmuch_config_path(path)) as fp:
         notmuch_settings.read_file(fp)
 
 
 def write_notmuch_settings(path=None):
-    if path is None:
-        path = os.environ.get('NOTMUCH_CONFIG', os.path.expanduser('~/.notmuch-config'))
-
-    with open(path, 'w+') as fp:
+    with open(_notmuch_config_path(path), 'w+') as fp:
         notmuch_settings.write(fp)
 
 


### PR DESCRIPTION
The location ~/.notmuch-config is still supported, but at some point notmuch also grew support for .config/notmuch/$profile/config as well.