### PR TITLE
gh actions: build package distributions in separate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,6 @@ jobs:
       - name: Install pypa/build and build-system deps
         run: |
           python3 -m pip install build setuptools setuptools_scm --user
-      - name: Build a binary wheel and a source tarball
-        run: python3 -m build
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v5
-        with:
-          name: python-package-distributions
-          path: dist/
       - name: Install dependencies
         shell: bash
         run: |
@@ -42,14 +35,3 @@ jobs:
         run: |
           python3 -m pip install freezegun --user
           pytest
-      - name: Docs
-        run: |
-          python3 -m pip install . --user
-          python3 -m pip install sphinx --user
-          sphinx-build -b html docs/ sphinx/html
-          sphinx-build -b man docs/ sphinx/man
-      - name: Store docs
-        uses: actions/upload-artifact@v5
-        with:
-          name: docs
-          path: sphinx/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,79 @@
-name: Release
-
-on:
-  release:
-    types:
-      - published
+name: Publish Python distribution to PyPI and TestPyPI
+on: push
 
 jobs:
-  release:
-    needs: [build-ubuntu]
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
-      - name: Install dependencies
+          python-version: "3.14"
+      - name: Install pypa/build and build-system deps
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools setuptools_scm wheel twine
-      - name: Build and publish (testpypi)
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.testpypi_token }}
-          TWINE_REPOSITORY: testpypi
+          python3 -m pip install build setuptools setuptools_scm --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v5
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Docs
         run: |
-          python setup.py sdist
-          twine upload dist/*
+          python3 -m pip install . --user
+          python3 -m pip install sphinx --user
+          sphinx-build -b html docs/ sphinx/html
+          sphinx-build -b man docs/ sphinx/man
+      - name: Store docs
+        uses: actions/upload-artifact@v5
+        with:
+          name: docs
+          path: sphinx/
+
+
+  testpypi-publish:
+    name: Upload release to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/afew/
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v6
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    needs:
+      - build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/afew/
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v6
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Publish them to testpypi on every push, and for all tags to pypi.