### PR TITLE
gh actions: don't publish to TestPyPi on every commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,28 +25,8 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-
-  testpypi-publish:
-    name: Upload release to TestPyPI
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/project/afew/
-    permissions:
-      id-token: write
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v6
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-
+  # No pushing to TestPyPi, see
+  # https://github.com/pypa/packaging-problems/issues/844#issuecomment-2513007085
   pypi-publish:
     name: Upload release to PyPI
     needs:


### PR DESCRIPTION
This runs into PEP 440, so
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ uploading on every commit to TestPyPi doesn't actually work.