### PR TITLE
Replace afew/version.py with importlib.metadata.version

### DIFF
--- a/afew/commands.py
+++ b/afew/commands.py
@@ -13,10 +13,10 @@ from afew.FilterRegistry import all_filters
 from afew.Settings import user_config_dir, get_filter_chain, \
     get_mail_move_rules, get_mail_move_age, get_mail_move_rename
 from afew.NotmuchSettings import read_notmuch_settings, get_notmuch_new_query
-from afew.version import version
+from importlib.metadata import version
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-V', '--version', action='version', version=version)
+parser.add_argument('-V', '--version', action='version', version=version("afew"))
 
 # the actions
 action_group = parser.add_argument_group(


### PR DESCRIPTION
Previously, `afew/version.py` was generated by setuptools. Without this file, one gets errors like this:

    Traceback (most recent call last):
      File "/nix/store/mkdw047dmy7ipd1g1pqyrjhp29ldasna-afew-4.0.1/bin/.afew-wrapped", line 6, in <module>
        from afew.commands import main
      File "/nix/store/mkdw047dmy7ipd1g1pqyrjhp29ldasna-afew-4.0.1/lib/python3.14/site-packages/afew/commands.py", line 16, in <module>
        from afew.version import version
    ModuleNotFoundError: No module named 'afew.version'