### PR TITLE
.gitignore: drop afew/version.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ bin/
 include/
 lib/
 /afew.egg-info
-afew/version.py
 /.eggs


### PR DESCRIPTION
This is not generated anymore since
e1fe4344de0ad5abfb39a844fd18a5aa3318e36b.